### PR TITLE
BYU Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 dist
 build
 eggs
+.eggs
 parts
 bin
 var

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Here is an ipython session showing the API.  I wrapped some of the output for re
 This package also provides some models to represent people at BYU. The `Person` model can be instantiated manually and used manually. By taking advantage of the `PersonFactory`, you can get an instantiated `Person` model that has information already filled out populated from various BYU web services. For example:
 
     1 >>> from byu_ws_sdk.helpers import PersonFactory
-    2 >>> pf = PersonFactory()
+    2 >>> pf = PersonFactory()  # assuming you have BYU_WS_KEY and BYU_WS_SECRET environment variables defined. Otherwise they should be passed in.
     3 >>> person = pf.get_person('jcougar2', ['full_name', 'byu_id', 'email'])
     4 >>> person.full_name
     4: u'Joseph Q. Cougar'

--- a/README.md
+++ b/README.md
@@ -98,3 +98,33 @@ Here is an ipython session showing the API.  I wrapped some of the output for re
         {'nonceKey': '57921',
          'nonceValue': 'G4qPJr5L3xI3KjXPw0g1mgWY8bzInQts7uctUfTAINm5ov3WCbXqRrTlFyECiiY/8rKGIqGUNDMxI9HlFvDEKg=='}
 
+
+## BYU Models
+This package also provides some models to represent people at BYU. The `Person` model can be instantiated manually and used manually. By taking advantage of the `PersonFactory`, you can get an instantiated `Person` model that has information already filled out populated from various BYU web services. For example:
+
+    1 >>> from byu_ws_sdk.helpers import PersonFactory
+    2 >>> pf = PersonFactory()
+    3 >>> person = pf.get_person('jcougar2', ['full_name', 'byu_id', 'email'])
+    4 >>> person.full_name
+    4: u'Joseph Q. Cougar'
+
+    5 >>> person.byu_id
+    5: u'64-586-3824'
+
+    6 >>> person.email
+    6: u'joe@primo.exlibris.com'
+
+    7 >>> person.net_id
+    7: 'jcougar2'
+
+    8 >>> pf.get_memberships(person, ['Employee', 'Student', 'test_gro_group'])
+    8: <byu_ws_sdk.models.Person at 0x7f70aa778d90>
+
+    9 >>> person.memberships
+    9: {'Employee': False, 'Student': False, 'test_gro_group': True}
+
+    10 >>> person.is_member('Employee')
+    10: False
+
+    11 >>> person.is_member('test_gro_group')
+    11: True

--- a/byu_ws_sdk/__init__.py
+++ b/byu_ws_sdk/__init__.py
@@ -1,1 +1,2 @@
 from .core import *
+from . import helpers, services

--- a/byu_ws_sdk/core.py
+++ b/byu_ws_sdk/core.py
@@ -4,7 +4,12 @@ The code that generates the Authorization HTTP header.
 __author__ = 'paul_eden@byu.edu'
 import os
 import xml.dom.minidom
-import simplejson
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
 import hashlib
 import hmac
 import base64
@@ -85,7 +90,7 @@ def get_ws_session(casNetId, casPassword, casTimeout=1, **kwargs):
     if not body:
         raise Exception("The WsSession-granting web service did not provide a WsSession."
                         "  Perhaps the username and password supplied are not valid?")
-    return simplejson.loads(body)
+    return json.loads(body)
 
 
 def get_nonce(apiKey, actor="", **kwargs):
@@ -106,7 +111,7 @@ def get_nonce(apiKey, actor="", **kwargs):
     response = requests.post(nonce_url.format(apiKey, actor), **kwargs)
     body = response.content
     try:
-        rvalue = simplejson.loads(body)
+        rvalue = json.loads(body)
     except:
         print(body)
         raise

--- a/byu_ws_sdk/helpers.py
+++ b/byu_ws_sdk/helpers.py
@@ -1,0 +1,228 @@
+from __future__ import unicode_literals
+
+from functools import partial
+import os
+import threading
+try:
+    from Queue import Queue
+except ImportError:
+    from queue import Queue
+import time
+import logging
+
+from byu_ws_sdk.core import ENCODING_URL, HTTP_METHOD_GET, KEY_TYPE_API
+from byu_ws_sdk.core import send_ws_request, get_http_authorization_header
+
+from byu_ws_sdk import services
+from byu_ws_sdk.services import ismember
+from byu_ws_sdk.models import Person
+
+log = logging.getLogger(__name__)
+
+_get_header = partial(get_http_authorization_header,
+                      keyType=KEY_TYPE_API,
+                      encodingType=ENCODING_URL,
+                      httpMethod=HTTP_METHOD_GET,
+                      actorInHash=False,
+                      )
+
+
+def _threadable(func):
+    def wrapped_func(q, *args, **kwargs):
+        rtn = func(*args, **kwargs)
+        q.put(rtn)
+
+    def wrap(*args, **kwargs):
+        q = Queue()
+        t = threading.Thread(target=wrapped_func,
+                             args=(q,) + args, kwargs=kwargs)
+        t.daemon = False
+        t.started = time.time()
+        t.start()
+        t.result = q
+        return t
+
+    return wrap
+
+
+@_threadable
+def _get_response(service, service_caller, information):
+    response = {}
+    if service['name'] == 'ismember':
+        response = service_caller(service, group_id=information)
+    else:
+        log.debug('called service: {0}'.format(service['name']))
+        if any([i in service['attributes'] for i in information]):
+            response = service_caller(service)
+    return response
+
+
+def _remove_index(dictionary, index):
+    depth = index.split('.')
+    base = depth[-1]
+    for attr in depth:
+        if base in dictionary:
+            del dictionary[base]
+            break
+        elif attr in dictionary:
+            dictionary = dictionary[attr]
+
+
+def _service_caller(service, net_id, actor, byu_key, byu_secret, **kwargs):
+    if service['name'] == 'ismember':
+        group_id = kwargs['group_id']
+        del kwargs['group_id']
+        url = service['url'].format(net_id=net_id, group_id=group_id)
+    else:
+        url = service['url'].format(net_id=net_id)
+    auth_header = _get_header(byu_key,
+                              byu_secret,
+                              url=url,
+                              actor=actor)
+    headers = {'Authorization': auth_header}
+    content, status_code, headers, response = send_ws_request(url,
+                                                              HTTP_METHOD_GET,
+                                                              headers=headers,
+                                                              **kwargs)
+    if status_code == 200:
+        try:
+            response = response.json()
+            response = response[service['root']]['response']
+            for to_remove in service.get('remove', []):
+                _remove_index(response, to_remove)
+            return response
+        except:
+            return BYUServiceError("Service invalid: {0}".format(url),
+                                   'unknown')
+    else:
+        return BYUServiceError("Service failed: {0} ({1})".format(url,
+                                                                  status_code),
+                               content)
+
+
+class PersonFactory(object):
+    def __init__(self, actor=None, byu_key=None, byu_secret=None,
+                 **extra_request_kwargs):
+        self.byu_key = byu_key
+        if byu_key is None:
+            self.byu_key = os.environ.get('BYU_WS_KEY')
+
+        self.byu_secret = byu_secret
+        if byu_secret is None:
+            self.byu_secret = os.environ.get('BYU_WS_SECRET')
+
+        if self.byu_key is None or self.byu_secret is None:
+            raise BYUServiceError(("Must provide a BYU web service key and "
+                                   "shared secret."),
+                                  BYUServiceError.INVALID_CREDENTIALS)
+
+        if 'timeout' not in extra_request_kwargs:
+            extra_request_kwargs['timeout'] = 3  # default timeout to 3 seconds
+
+        self.extra_request_kwargs = extra_request_kwargs
+        self.actor = actor
+
+    def _get_service_caller(self, net_id, actor):
+        """
+        Returns a service_caller function.
+
+        Arguments:
+            net_id - netId of the person to get information about.
+            actor - netId of the person requesting the information.
+        """
+        return partial(_service_caller,
+                       net_id=net_id,
+                       actor=actor,
+                       byu_key=self.byu_key,
+                       byu_secret=self.byu_secret,
+                       **self.extra_request_kwargs)
+
+    def get_person(self, net_id, information=None):
+        information = information if information else []
+
+        actor = self.actor if self.actor else net_id
+        person = Person(net_id, actor)
+
+        call_service = self._get_service_caller(person.net_id, person.actor)
+        started = time.time()
+        responses = self._request_information(call_service, information)
+        exceptions = []
+        for name, response in responses.items():
+            value = response[1].result.get()
+            done = time.time() - response[1].started
+            log.debug("service done: {0} (took {1} sec)".format(name, done))
+            if value == '':
+                continue
+            if isinstance(value, BYUServiceError):
+                exceptions.append(value)
+            else:
+                func = response[0]
+                person.set_raw_service_response(name, value)
+                person = func(value, person, information)
+        if exceptions:
+            raise BYUServiceError("Exceptions on service calls", exceptions)
+        done = time.time() - started
+        log.debug("all services took {0} sec".format(done))
+        return person
+
+    def get_memberships(self, person, groups, actor=None):
+        """
+        Person instance populated with additional group membership information.
+
+        Arguments:
+            person - a object instance that has a add_membership method taking
+                     the group_id and a boolean indicating membership.
+            groups - a list of group_ids to check membership on.
+            actor - the actor to use to check group memberships
+                    (default person.actor)
+        """
+        actor = actor if actor else person.actor
+        call_service = self._get_service_caller(person.net_id, actor)
+        responses = self._request_memberships(call_service, groups)
+        exceptions = []
+        for group, thread in responses:
+            value = thread.result.get()
+            if value == '':
+                continue
+            if isinstance(value, BYUServiceError):
+                exceptions.append(value)
+            else:
+                person = ismember.parse_response(value, person, group)
+        if exceptions:
+            raise BYUServiceError("Exceptions on service calls", exceptions)
+
+        return person
+
+    def _request_information(self, caller, information):
+        rtn_services = {}
+        for service in services.ALL_PERSON_SERVICES:
+            module_name = '.'.join(['byu_ws_sdk.services', service])
+            service_module = __import__(module_name,
+                                        fromlist=['SERVICE', 'parse_response'])
+            parser = service_module.parse_response
+            service = service_module.SERVICE
+            log.debug("calling service: {0}".format(service['name']))
+            rtn_services[service['name']] = (parser,
+                                             _get_response(service,
+                                                           caller,
+                                                           information))
+        return rtn_services
+
+    def _request_memberships(self, caller, groups):
+        rtn_groups = []
+        for group in groups:
+            rtn_groups.append((group, _get_response(ismember.SERVICE,
+                                                    caller,
+                                                    group)))
+        return rtn_groups
+
+
+class BYUServiceError(Exception):
+    INVALID_CREDENTIALS = 'Invalid credentials provided.'
+
+    def __init__(self, message, error):
+        super(BYUServiceError, self).__init__(message)
+        self.error = error
+
+    def __str__(self):
+        return "{0.message}: \n\n{0.error}".format(self)

--- a/byu_ws_sdk/models.py
+++ b/byu_ws_sdk/models.py
@@ -1,0 +1,112 @@
+from __future__ import unicode_literals
+
+
+class Person(object):
+
+    """A person at BYU."""
+
+    def __init__(self, net_id, actor=None):
+        """
+        Represents a person (students/faculty/staff) at BYU.
+
+        Arguments:
+            net_id - the NetId of the person.
+            actor - the NetId of the person wanting the information,
+                    (default: net_id)
+        """
+        self.net_id = net_id
+        self.actor = actor if actor else net_id
+        self._raw_service_responses = {}
+        # personnames service attributes
+        self.first_name = None
+        self.full_name = None
+        self.given_names = None
+        self.name = None
+        self.sort_name = None
+        self.surname = None
+        self.surname_position = None
+        # personsummary service attributes
+        self.byu_id = None
+        self.byu_id_issue_number = None
+        self.byu_id_number = None
+        self.courses = None
+        self.department = None
+        self.email = None
+        self.employee_role = None
+        self.employee_role_parts = None
+        self.gender = None
+        self.hired_date = None
+        self.job_title = None
+        self.person_id = None
+        self.retirement_date = None
+        self.student_role = None
+        self.memberships = {}
+
+    def get_raw_service_response(self, service_name):
+        rtn = self._raw_service_responses.get(service_name, None)
+        if rtn is None:
+            raise ValueError('No raw service response for {}'.format(
+                service_name))
+        return rtn
+
+    def set_raw_service_response(self, service_name, response):
+        self._raw_service_responses[service_name] = response
+
+    def is_member(self, group_id):
+        return self.memberships.get(group_id, False)
+
+    def add_membership(self, group_id, is_member=True):
+        self.memberships[group_id] = is_member
+
+    def __str__(self):
+        return str(self.__unicode__())
+
+    def __unicode__(self):
+        return unicode(self.net_id)
+
+
+class Course(object):
+
+    """
+    A course at BYU.
+
+    The resulting instantiated instance will have the following attributes.
+
+    catalog_entry - the catalog_entry value passed in on instantiation
+    teaching_area - the teaching_area value passed in on instantiation
+    instructor - the instructor value passed in on instantiation
+    course_number - the first portion of the catalog_entry value, before the -
+    section_number - the second portion of the catalog_entry value, after -
+    normalized_teaching_area - lowercased and space replaced teaching_area
+    """
+
+    def __init__(self, catalog_entry, teaching_area, instructor):
+        """
+        A BYU course is instantiated with the following required arguments.
+
+        Arguments:
+            catalog_entry - catalog course number of the format,
+                            [course number]-[section number]
+            teaching_area - the teaching area of the course
+            instructor - instructors name
+        """
+        self.catalog_entry = catalog_entry.strip()
+        self.teaching_area = teaching_area.strip()
+        self.instructor = instructor.strip()
+        self.course_number = self.catalog_entry.split('-')[0]
+        self.section_number = self.catalog_entry.split('-')[1]
+        self.normalized_teaching_area = (self
+                                         .teaching_area
+                                         .lower()
+                                         .replace(' ', ''))
+
+    def __str__(self):
+        return str(self.__unicode__())
+
+    def __unicode__(self):
+        return ("{0.teaching_area} {0.catalog_entry} by {0.instructor}"
+                .format(self))
+
+    def __repr__(self):
+        return ("Course('{0.catalog_entry}', '{0.teaching_area}', "
+                "'{0.instructor}')".format(self))

--- a/byu_ws_sdk/models.py
+++ b/byu_ws_sdk/models.py
@@ -40,6 +40,7 @@ class Person(object):
         self.person_id = None
         self.retirement_date = None
         self.student_role = None
+        # is member information
         self.memberships = {}
 
     def get_raw_service_response(self, service_name):
@@ -53,9 +54,24 @@ class Person(object):
         self._raw_service_responses[service_name] = response
 
     def is_member(self, group_id):
+        """
+        Returns bool indicating if the person has membership in a group.
+
+        Arguments:
+            group_id - string of the group name.
+
+        Returns False by default if the group_id isn't found.
+        """
         return self.memberships.get(group_id, False)
 
     def add_membership(self, group_id, is_member=True):
+        """
+        Sets membership in a group.
+
+        Arguments:
+            group_id - string of the group name.
+            is_member - bool indicating membership in the group (default True).
+        """
         self.memberships[group_id] = is_member
 
     def __str__(self):

--- a/byu_ws_sdk/models.py
+++ b/byu_ws_sdk/models.py
@@ -62,7 +62,7 @@ class Person(object):
         return str(self.__unicode__())
 
     def __unicode__(self):
-        return unicode(self.net_id)
+        return self.net_id
 
 
 class Course(object):

--- a/byu_ws_sdk/services/__init__.py
+++ b/byu_ws_sdk/services/__init__.py
@@ -1,0 +1,4 @@
+
+ALL_PERSON_SERVICES = ['personsummary',
+                       'personnames',
+                       ]

--- a/byu_ws_sdk/services/ismember.py
+++ b/byu_ws_sdk/services/ismember.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+
+
+def parse_response(response, person, group):
+    person.add_membership(group, response.get('isMember', False))
+    return person
+
+
+SERVICE = {
+    'name': 'ismember',
+    'url': 'https://ws.byu.edu/rest/v1/identity/person/isMember/{group_id}/{net_id}.json',  # noqa
+    'root': 'isMember Service',
+}

--- a/byu_ws_sdk/services/personnames.py
+++ b/byu_ws_sdk/services/personnames.py
@@ -1,0 +1,56 @@
+from __future__ import unicode_literals
+
+
+# Helper functions
+def __make_name(given_name, surname, position):
+    if position == 'L':
+        name = "{given_name} {surname}"
+    else:
+        name = "{surname} {given_name}"
+    return name.format(given_name=given_name, surname=surname).strip()
+
+
+def __get_surname_position(response, person):
+    surname_position_func = SERVICE['attributes']['surname_position']
+    return surname_position_func(response, person)
+
+
+# Attribute parsing functions
+def _name(response, person):
+    surname_position = __get_surname_position(response, person)
+    first_name = SERVICE['attributes']['first_name'](response, person)
+    surname = SERVICE['attributes']['surname'](response, person)
+    return __make_name(first_name, surname, surname_position)
+
+
+def _full_name(response, person):
+    surname_position = __get_surname_position(response, person)
+    given_names = SERVICE['attributes']['given_names'](response, person)
+    surname = SERVICE['attributes']['surname'](response, person)
+    return __make_name(given_names, surname, surname_position)
+
+
+# Service response parser and information
+def parse_response(response, person, information):
+    if response:
+        attributes = SERVICE['attributes'].keys()
+        for info in [i for i in information if i in attributes]:
+            value = SERVICE['attributes'][info](response, person)
+            setattr(person, info, value)
+    return person
+
+
+SERVICE = {
+    'name': 'personnames',
+    'url': 'https://ws.byu.edu/rest/v2.0/identity/person/PRO/personNames.cgi/{net_id}.json',  # noqa
+    'root': 'PersonNamesService',
+    'attributes': {
+        'first_name': lambda res, p: res['preferred_name']['preferred_first_name'],  # noqa
+        'full_name': _full_name,
+        'given_names': lambda res, p: res['official_name']['rest_of_name'],
+        'name': _name,
+        'sort_name': lambda res, p: res['official_name']['sort_name'],
+        'surname': lambda res, p: res['official_name']['surname'],
+        'surname_position': lambda res, p: res['official_name']['surname_position'],  #noqa
+    },
+}

--- a/byu_ws_sdk/services/personsummary.py
+++ b/byu_ws_sdk/services/personsummary.py
@@ -1,0 +1,83 @@
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+SERVICE_DATE_FORMAT = '%Y-%m-%d'
+
+
+# Helper functions
+def __make_date(date_string):
+    if date_string:
+        try:
+            return datetime.strptime(date_string, SERVICE_DATE_FORMAT).date()
+        except ValueError:
+            pass
+    return None
+
+
+# Attribute parsing functions
+def _byu_id_number(response, person):
+    byu_id = SERVICE['attributes']['byu_id'](response, person)
+    issue_number_func = SERVICE['attributes']['byu_id_issue_number']
+    issue_number = issue_number_func(response, person)
+    return "{0} {1}".format(byu_id, issue_number)
+
+
+def _employee_role_parts(response, person):
+    roles = SERVICE['attributes']['employee_role'](response, person)
+    return roles.split('/')
+
+
+def _hired_date(response, person):
+    date_string = (response['employee_information']
+                   .get('date_hired', {})
+                   .get('date', ''))
+    return __make_date(date_string)
+
+
+def _retirement_date(response, person):
+    date_string = response['employee_information'].get('retirement_date', '')
+    return __make_date(date_string)
+
+
+def _email(response, person):
+    unlisted = response['contact_information']['email_address_unlisted']
+    email = response['contact_information']['email']
+    if not unlisted or person.net_id == person.actor:
+        return email
+    return 'Unlisted'
+
+
+# Service response parser and information
+def parse_response(response, person, information):
+    if response:
+        attributes = SERVICE['attributes'].keys()
+        for info in [i for i in information if i in attributes]:
+            value = SERVICE['attributes'][info](response, person)
+            setattr(person, info, value)
+    return person
+
+
+SERVICE = {
+    'name': 'personsummary',
+    'url': 'https://ws.byu.edu/rest/v2.0/identity/person/PRO/personSummary.cgi/{net_id}.json',  # noqa
+    'root': 'PersonSummaryService',
+    'remove': [
+        'identifiers.ssn',
+    ],
+    'attributes': {
+        'byu_id': lambda res, p: res['identifiers']['byu_id'],
+        'byu_id_issue_number': lambda res, p: res['identifiers']['byu_id_issue_number'],  # noqa
+        'byu_id_number': _byu_id_number,
+        'department': lambda res, p: res['employee_information']['department'],
+        'email': _email,
+        'employee_role': lambda res, p: res['employee_information']['employee_role'],  #noqa
+        'employee_role_parts': _employee_role_parts,
+        'gender': lambda res, p: res['personal_information']['gender'],
+        'hired_date': _hired_date,
+        'job_title': lambda res, p: res['employee_information']['job_title'],
+        'person_id': lambda res, p: res['identifiers']['person_id'],
+        'retirement_date': _retirement_date,
+        'student_role': lambda res, p: res['student_information']['student_role'],  # noqa
+    },
+}

--- a/byu_ws_sdk/test/test_byu_ws_sdk_with_input.py
+++ b/byu_ws_sdk/test/test_byu_ws_sdk_with_input.py
@@ -1,6 +1,7 @@
 import unittest
 import byu_ws_sdk as oit
 import getpass
+import os
 
 
 def get_input(prompt):
@@ -20,8 +21,12 @@ class TestOITWebServicesLibraryInput(unittest.TestCase):
         self.assertTrue('personId' in res)
 
     def test_authorize_request(self):
-        apiKey = get_input("API Key: ")
-        sharedSecret = getpass.getpass("Shared secret: ")
+        apiKey = os.getenv('BYU_API_KEY')
+        sharedSecret = os.getenv('BYU_API_SECRET')
+        if not apiKey:
+            apiKey = get_input("API Key: ")
+        if not sharedSecret:
+            sharedSecret = getpass.getpass("Shared secret: ")
         headerValue = oit.get_http_authorization_header(apiKey,
                                                         sharedSecret,
                                                         oit.KEY_TYPE_API,

--- a/byu_ws_sdk/test/test_helpers.py
+++ b/byu_ws_sdk/test/test_helpers.py
@@ -27,7 +27,7 @@ class TestPersonFactory(unittest.TestCase):
 
     def test_get_memberships(self):
         person = self.pf.get_memberships(self.p, ['Employee', 'Student'])
-        person = self.pf.get_memberships(self.p, ['HSE'], 'ryanamy')
+        person = self.pf.get_memberships(self.p, ['test_gro_group'], 'jcougar2')
         self.assertEquals(person.is_member('Employee'), False)
         self.assertEquals(person.is_member('Student'), False)
-        self.assertEquals(person.is_member('HSE'), True)
+        self.assertEquals(person.is_member('test_gro_group'), True)

--- a/byu_ws_sdk/test/test_helpers.py
+++ b/byu_ws_sdk/test/test_helpers.py
@@ -1,0 +1,33 @@
+import unittest
+from byu_ws_sdk.helpers import PersonFactory
+import os
+
+
+class TestPersonFactory(unittest.TestCase):
+    def setUp(self):
+        key = os.getenv('BYU_API_KEY')
+        secret = os.getenv('BYU_API_SECRET')
+        cert = os.getenv('BYU_API_CERT', False)
+        self.pf = PersonFactory(
+            byu_key=key,
+            byu_secret=secret,
+            verify=cert,
+        )
+        self.p = self.pf.get_person('jcougar2',
+                                    ['first_name', 'full_name', 'byu_id'])
+
+    def tearDown(self):
+        pass
+
+    def test_get_person(self):
+        self.assertEquals(self.p.first_name, 'Joe')
+        self.assertEquals(self.p.surname, None)
+        self.assertEquals(self.p.full_name, 'Joseph Q. Cougar')
+        self.assertEquals(self.p.byu_id, '64-586-3824')
+
+    def test_get_memberships(self):
+        person = self.pf.get_memberships(self.p, ['Employee', 'Student'])
+        person = self.pf.get_memberships(self.p, ['HSE'], 'ryanamy')
+        self.assertEquals(person.is_member('Employee'), False)
+        self.assertEquals(person.is_member('Student'), False)
+        self.assertEquals(person.is_member('HSE'), True)

--- a/byu_ws_sdk/test/test_models.py
+++ b/byu_ws_sdk/test/test_models.py
@@ -1,0 +1,50 @@
+import unittest
+from byu_ws_sdk.models import Person
+
+
+class TestPersonModel(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_instantiate_person(self):
+        net_id = 'test'
+        actor = 'test2'
+        p = Person(net_id)
+        pb = Person(net_id, actor)
+
+        self.assertEquals(p.net_id, net_id)
+        self.assertEquals(p.actor, net_id)
+        self.assertEquals(str(p), net_id)
+        self.assertEquals(p._raw_service_responses, {})
+        self.assertEquals(p.first_name, None)
+        self.assertEquals(p.byu_id, None)
+        self.assertEquals(pb.net_id, net_id)
+        self.assertEquals(pb.actor, actor)
+        self.assertEquals(str(pb), net_id)
+        self.assertEquals(pb._raw_service_responses, {})
+        self.assertEquals(pb.first_name, None)
+        self.assertEquals(pb.byu_id, None)
+
+    def test_membership_access_person(self):
+        p = Person('test')
+        p.add_membership('Employee')
+        p.add_membership('Student', False)
+        p.add_membership('Staff', True)
+        p.add_membership('my_gro_group', is_member=True)
+
+        self.assertEquals(p.is_member('Employee'), True)
+        self.assertEquals(p.is_member('Student'), False)
+        self.assertEquals(p.is_member('Staff'), True)
+        self.assertEquals(p.is_member('my_gro_group'), True)
+        self.assertEquals(p.is_member('something_not_there'), False)
+
+    def test_raw_service_response_access_person(self):
+        p = Person('test')
+        sr = {'a': 'testing'}
+        p.set_raw_service_response('personsummary', sr)
+
+        self.assertEquals(p.get_raw_service_response('personsummary'), sr)
+        self.assertRaises(ValueError, lambda: p.get_raw_service_response('a'))


### PR DESCRIPTION
Proposed features to simplify the use of BYU web services in applications.

These changes would provide a `Person` model (and in the future a `Course` model along with others as needed) to be used in Python programs to represent a person at BYU (student, staff, faculty).  The basic usage of how this might work can be found in the included `test_helpers.py` file (specifically in the `setUp` method of the test case found there).

The `Person` model could be instantiated alone and populated as needed, supporting many use cases, as well as allowing programs to use the same model to represent a person at BYU even if they are not getting information about that person from BYU web services.

In the `helpers.py` file is contained a `PersonFactory` class that could provide a simple (multithreaded) way of calling multiple web services to populate a `Person` model.

The main benefit to these features being that, one would not have to know much about the underlying BYU web services to take advantage of the information they offer. This solution makes some assumptions about which bits of information about a person should come from which services. This however isn't restrictive, programs could still call other services and populate information in a `Person` model manually (without the help of the `PersonFactory` helper).

I plan on updating the README file with examples of how to use these new features as well as add more comments to the code itself before this request is accepted, but I just wanted to get it submitted so we can start discussing it, if need be. 